### PR TITLE
Upgrade Gradle files settings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,13 +13,13 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++11 -frtti -fexceptions -fopenmp"
-                abiFilters  'armeabi', 'armeabi-v7a'
+                abiFilters  'arm64-v8a'
             }
         }
         ndk {
             moduleName "native-lib"
             ldLibs "log gomp"//实现__android_log_print
-            abiFilters "armeabi", "armeabi-v7a"
+            abiFilters 'arm64-v8a'
         }
     }
     buildTypes {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:4.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip


### PR DESCRIPTION
- The project uses Gradle 3.3 is not compatible with Java 11 or newer, so the wrapper has been upgraded to the minimum supported version 6.5.1.
- 'armeabi' ABI is not anymore a supported platform, it has been updated to 'arm64-v8a' ABI platform.
