### PR TITLE
Fixed issue with the static assert error on map container 'is_same' requirement type.

### DIFF
--- a/app/src/main/cpp/ORB/include/LoopClosing.h
+++ b/app/src/main/cpp/ORB/include/LoopClosing.h
@@ -47,7 +47,7 @@ public:
 
     typedef pair<set<KeyFrame*>,int> ConsistentGroup;    
     typedef map<KeyFrame*,g2o::Sim3,std::less<KeyFrame*>,
-        Eigen::aligned_allocator<std::pair<const KeyFrame*, g2o::Sim3> > > KeyFrameAndPose;
+        Eigen::aligned_allocator<std::pair<KeyFrame* const, g2o::Sim3> > > KeyFrameAndPose;
 
 public:
 


### PR DESCRIPTION
- Reported compilation error:
` [...]
ORB-SLAM2-based-AR-on-Android/app/src/main/cpp/ORB/Thirdparty/DBoW2/DBoW2/BowVector.h:14: /home/dev/workspace/dev-tools/Android/Sdk/ndk/21.1.6352462/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/map:910:5: error: static_assert failed due to requirement 'is_same<std::__ndk1::pair<const ORB_SLAM2::KeyFrame *, g2o::Sim3>, std::__ndk1::pair<ORB_SLAM2::KeyFrame *const, g2o::Sim3> >::value' "Allocator::value_type must be same type as value_type"
[...]
`
-Modified 'KeyFrameAndPose' map value type to validate the static assert check.
